### PR TITLE
vega-element-cdn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ node_modules
 
 # bower directory
 bower_components
-es5
 
 # gh_pages
 gh_pages

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ v2 is a breaking change from v1 as it is an upgrade in major versions for both P
 - [**v2**](https://github.com/PolymerVis/vega-element/tree/polymer2) Supports Polymer 2.0, Vega 3.0, and Vega-Lite 2.0
 - [**v1**](https://github.com/PolymerVis/vega-element/tree/polymer1) Supports Polymer 1.0 and Vega 2.0
 
+## Disclaimer
+PolymerVis is a personal project and is NOT in any way affliated with Vega, Vega-Lite, Polymer or Google.
+
 ## Installation
 
 ```

--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
     "iron-ajax": "PolymerElements/iron-ajax#^2.0.0"
   },
   "resolutions": {
-    "polymer": "^2.0.0"
+    "polymer": "^2.0.0",
+    "vega": "^3.0.5"
   }
 }

--- a/polymer.json
+++ b/polymer.json
@@ -1,5 +1,27 @@
 {
+  "shell": "vega-element.html",
+  "fragments": [
+    "d3.html",
+    "vega-core.html",
+    "vega.html",
+    "vega-lite.html",
+    "vega-tooltip.html",
+    "vega-signal.html",
+    "vega-data.html",
+    "vega-data-stream.html"
+  ],
   "lint": {
     "rules": ["polymer-2"]
-  }
+  },
+  "builds": [
+    {
+      "name": "es5",
+      "js": {"minify": true, "compile": true},
+      "css": {"minify": true},
+      "html": {"minify": true},
+      "bundle": true,
+      "addServiceWorker": false,
+      "addPushManifest": false
+    }
+  ]
 }

--- a/vega-element-cdn.html
+++ b/vega-element-cdn.html
@@ -1,0 +1,6 @@
+<link rel="import" href="https://polygit.org/components/polymer/polymer-element.html">
+<link rel="import" href="https://polygit.org/components/polymer/lib/utils/flattened-nodes-observer.html">
+<link rel="import" href="https://polygit.org/components/polymer/lib/utils/debounce.html">
+<link rel="import" href="https://polygit.org/components/polymer/lib/mixins/mutable-data.html">
+<link rel="import" href="https://rawgit.com/PolymerVis/polymer-vis/master/polymer-vis.html">
+<link rel="import" href="vega-element.html">


### PR DESCRIPTION
Added vega-element-cdn.html for import via cdn.
Added bower resolution to ensure latest Vega is used instead of the beta-version defined in Vega-Lite.